### PR TITLE
Use production studio version from community distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
-WebJar for orientdb-studio
+# [WebJar](http://webjars.org) for [orientdb-studio](https://github.com/orientechnologies/orientdb-studio)
 
-More info: http://webjars.org
+Uses production studio build (bundled with [orientdb-community distribution](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.orientechnologies%22%20AND%20a%3A%22orientdb-community%22))
 
-Upstream: https://github.com/orientechnologies/orientdb-studio
+NOTE: Usually the same studio version is provided for every minor distribution version (e.g. for 2.0.0-2.0.14), so in most cases it will be ok to use "older" studio.
+
+### Studio version
+
+Change `orient.version` property in pom file with required orient version (e.g. 2.0.12)
+
+### Build
+
+For local (test) build do 
+
+```bash
+$mvn clean package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -11,16 +12,16 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>orientdb-studio</artifactId>
-    <version>2.0-M4-SNAPSHOT</version>
+    <version>2.0.12-SNAPSHOT</version>
     <name>orientdb-studio</name>
     <description>WebJar for orientdb-studio</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.0-M3</upstream.version>
-        <upstream.url>https://github.com/orientechnologies/orientdb-studio/archive/${upstream.version}.zip</upstream.url>
+        <orient.version>2.0.12</orient.version>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
+        <studio.unpack.dir>${project.build.directory}/studio</studio.unpack.dir>
         <requirejs>
             {
                 "paths": {
@@ -57,21 +58,53 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>extract orient-community distribution</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.orientechnologies</groupId>
+                                    <artifactId>orientdb-community</artifactId>
+                                    <version>${orient.version}</version>
+                                    <classifier>distribution</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <includes>**/studio-*.zip</includes>
+                            <!-- other configurations here -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
-                        <goals><goal>run</goal></goals>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                         <configuration>
                             <target>
-                                <echo message="download archive" />
-                                <get src="${upstream.url}" dest="${project.build.directory}/${project.artifactId}.zip" />
-                                <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
-                                <echo message="moving resources" />
+                                <echo message="unzip archive"/>
+                                <unzip dest="${studio.unpack.dir}">
+                                    <fileset dir="${project.build.directory}">
+                                        <include name="**/studio-*.zip"/>
+                                    </fileset>
+                                </unzip>
+                                <echo message="moving resources"/>
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/${project.artifactId}-${upstream.version}/app" />
+                                    <fileset dir="${studio.unpack.dir}/www/"/>
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Changed build from using studio repository tags (raw source version) to use production studio (with minified resources) version from community distribution.

I'm sure most people want to use this webjar for embedding studio into their application and production version will be much more suitable.
